### PR TITLE
add context manager

### DIFF
--- a/factorio_rcon/_factorio_rcon.py
+++ b/factorio_rcon/_factorio_rcon.py
@@ -1,5 +1,4 @@
 """RCON client for Factorio servers"""
-from __future__ import annotations
 import enum
 import functools
 import socket
@@ -405,8 +404,10 @@ class RCONClient(RCONSharedBase):
                 results[id_map[response.id]] = response.body.rstrip()
         return results
 
-    @handle_socket_errors(alive_socket_required=True)
-    def __enter__(self) -> RCONClient:
+    @handle_socket_errors(alive_socket_required=False)
+    def __enter__(self) -> "RCONClient":
+        if self.rcon_socket is None or self.rcon_failure:
+            self.connect()
         return self
 
     def __exit__(
@@ -631,8 +632,10 @@ class AsyncRCONClient(RCONSharedBase):
                 results[id_map[response.id]] = response.body.rstrip()
         return results
 
-    @handle_socket_errors(alive_socket_required=True)
-    async def __aenter__(self) -> AsyncRCONClient:
+    @async_handle_socket_errors(alive_socket_required=False)
+    async def __aenter__(self) -> "AsyncRCONClient":
+        if self.rcon_socket is None or self.rcon_failure:
+            await self.connect()
         return self
 
     async def __aexit__(

--- a/factorio_rcon/_factorio_rcon.py
+++ b/factorio_rcon/_factorio_rcon.py
@@ -1,10 +1,11 @@
 """RCON client for Factorio servers"""
+from __future__ import annotations
 import enum
 import functools
 import socket
 import struct
 from types import TracebackType
-from typing import Any, Callable, Dict, NamedTuple, Optional, TypeVar, cast, Self
+from typing import Any, Callable, Dict, NamedTuple, Optional, TypeVar, cast
 
 try:
     import anyio
@@ -403,18 +404,17 @@ class RCONClient(RCONSharedBase):
             else:
                 results[id_map[response.id]] = response.body.rstrip()
         return results
-    
-    def __enter__(self) -> Self:
-        if self.rcon_socket is None:
-            raise RCONNotConnected(NOT_CONNECTED)
+
+    @handle_socket_errors(alive_socket_required=True)
+    def __enter__(self) -> RCONClient:
         return self
-    
+
     def __exit__(
-            self, 
-            exc_type: Optional[type[BaseException]], 
-            exc_value: Optional[BaseException], 
-            traceback: Optional[TracebackType]
-        ) -> None:
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         self.close()
 
 
@@ -630,16 +630,17 @@ class AsyncRCONClient(RCONSharedBase):
             else:
                 results[id_map[response.id]] = response.body.rstrip()
         return results
-    
-    async def __aenter__(self) -> Self:
+
+    @handle_socket_errors(alive_socket_required=True)
+    async def __aenter__(self) -> AsyncRCONClient:
         return self
-    
+
     async def __aexit__(
-            self,
-            exc_type: Optional[type[BaseException]], 
-            exc_value: Optional[BaseException], 
-            traceback: Optional[TracebackType]
-        ) -> None:
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         await self.close()
 
 

--- a/factorio_rcon/_factorio_rcon.py
+++ b/factorio_rcon/_factorio_rcon.py
@@ -3,7 +3,8 @@ import enum
 import functools
 import socket
 import struct
-from typing import Any, Callable, Dict, NamedTuple, Optional, TypeVar, cast
+from types import TracebackType
+from typing import Any, Callable, Dict, NamedTuple, Optional, TypeVar, cast, Self
 
 try:
     import anyio
@@ -402,6 +403,19 @@ class RCONClient(RCONSharedBase):
             else:
                 results[id_map[response.id]] = response.body.rstrip()
         return results
+    
+    def __enter__(self) -> Self:
+        if self.rcon_socket is None:
+            raise RCONNotConnected(NOT_CONNECTED)
+        return self
+    
+    def __exit__(
+            self, 
+            exc_type: Optional[type[BaseException]], 
+            exc_value: Optional[BaseException], 
+            traceback: Optional[TracebackType]
+        ) -> None:
+        self.close()
 
 
 class AsyncRCONClient(RCONSharedBase):
@@ -616,6 +630,17 @@ class AsyncRCONClient(RCONSharedBase):
             else:
                 results[id_map[response.id]] = response.body.rstrip()
         return results
+    
+    async def __aenter__(self) -> Self:
+        return self
+    
+    async def __aexit__(
+            self,
+            exc_type: Optional[type[BaseException]], 
+            exc_value: Optional[BaseException], 
+            traceback: Optional[TracebackType]
+        ) -> None:
+        await self.close()
 
 
 INVALID_PASS = "The RCON password is incorrect"


### PR DESCRIPTION
proposal: add a context manager for lighter syntax and guarantee connection closure so instead of this:
```py
from factorio_rcon import RCONClient

client = RCONClient("127.0.0.1", 12345, "mypassword")
response = client.send_command("/help")
client.close()
```
we can simply do:
```py
from factorio_rcon import RCONClient

with RCONClient("127.0.0.1", 12345, "mypassword") as client:
    response = client.send_command("/help")
```
also for async clients:
```py
from factorio_rcon import AsyncRCONClient

async with AsyncRCONClient("127.0.0.1", 12345, "mypassword") as client:
    response = await client.send_command("/help")
```

I have to admit that this is my first pull request and I may be doing things wrong, I also haven't found a suitable docstring to these methods.

(also this probably need it's own ticket/pull request but you're using assert in prod in both ``receive_exactly`` methods instead of raising RCONNotConnected)