### PR TITLE
add a stub file to comply with PEP 561

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools>=62.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.package-data]
+"*" = ["py.typed"]
+
 [project]
 name = "factorio-rcon-py"
 version = "2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["setuptools>=62.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.package-data]
-"*" = ["py.typed"]
-
 [project]
 name = "factorio-rcon-py"
 version = "2.0.1"


### PR DESCRIPTION
Proposal (again): Add a py.typed file to ensure compliance with PEP 561. This will prevent users with strict type checkers (like me), from encountering error messages.