### PR TITLE
Fix type annotations for py3.8

### DIFF
--- a/factorio_rcon/_factorio_rcon.py
+++ b/factorio_rcon/_factorio_rcon.py
@@ -4,7 +4,7 @@ import functools
 import socket
 import struct
 from types import TracebackType
-from typing import Any, Callable, Dict, NamedTuple, Optional, TypeVar, cast
+from typing import Any, Callable, Dict, NamedTuple, Optional, Type, TypeVar, cast
 
 try:
     import anyio
@@ -413,7 +413,7 @@ class RCONClient(RCONSharedBase):
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
+        exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
@@ -642,7 +642,7 @@ class AsyncRCONClient(RCONSharedBase):
 
     async def __aexit__(
         self,
-        exc_type: Optional[type[BaseException]],
+        exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:


### PR DESCRIPTION
Versions newer than 2.0.1 do not work on py3.8. This change fixes that.

```
Traceback (most recent call last):
  [...]
    import factorio_rcon
  File ".../factorio_rcon/__init__.py", line 1, in <module>
    from ._factorio_rcon import (
  File ".../factorio_rcon/_factorio_rcon.py", line 177, in <module>
    class RCONClient(RCONSharedBase):
  File ".../factorio_rcon/_factorio_rcon.py", line 416, in RCONClient
    exc_type: Optional[type[BaseException]],
TypeError: 'type' object is not subscriptable
```